### PR TITLE
chore(package): update markdownlint-cli to version 0.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "express": "^4.16.4",
     "husky": "^3.0.0",
     "lint-staged": "^9.0.2",
-    "markdownlint-cli": "^0.16.0",
+    "markdownlint-cli": "^0.18.0",
     "mocha": "^6.0.2",
     "nyc": "^14.0.0",
     "semantic-release": "^15.13.3",


### PR DESCRIPTION
Closes #32